### PR TITLE
fix: wrong aws lambda handler name

### DIFF
--- a/projects/my_aws_lambda_project/serverless.yml
+++ b/projects/my_aws_lambda_project/serverless.yml
@@ -11,7 +11,7 @@ provider:
 
 functions:
   hello:
-    handler: example.messages_lambda.core.handler
+    handler: example.greet_aws_lambda.core.handler
 
 plugins:
   - serverless-python-requirements


### PR DESCRIPTION
fixes the following two errors:

```zsh
➜  my_aws_lambda_project git:(main) ✗ serverless invoke --function hello         <aws:developer>
Running "serverless" from node_modules
{
    "errorMessage": "Unable to import module 'example.messages_lambda.core': No module named 'example.messages_lambda'",
    "errorType": "Runtime.ImportModuleError",
    "requestId": "9190cef9-a491-4729-b1d8-af66a6593314",
    "stackTrace": []
}
Environment: darwin, node 18.14.0, framework 3.30.1 (local) 3.34.0v (global), plugin 6.2.3, SDK 4.5.1
Credentials: Local, "developer" profile
Docs:        docs.serverless.com
Support:     forum.serverless.com
Bugs:        github.com/serverless/serverless/issues

Error:
Invoked function failed
```

```zsh
➜  my_aws_lambda_project git:(main) ✗ serverless invoke local --function hello   <aws:developer>
Running "serverless" from node_modules
Traceback (most recent call last):
  File "/Users/yhkee0404/python-polylith-example/projects/my_aws_lambda_project/node_modules/serverless/lib/plugins/aws/invoke-local/runtime-wrappers/invoke.py", line 80, in <module>

    module = import_module(args.handler_path.replace('/', '.'))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yhkee0404/.asdf/installs/python/3.11.9/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1126, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1140, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'example.messages_lambda'

Environment: darwin, node 18.14.0, framework 3.30.1 (local) 3.34.0v (global), plugin 6.2.3, SDK 4.5.1
Credentials: Local, "developer" profile
Docs:        docs.serverless.com
Support:     forum.serverless.com
Bugs:        github.com/serverless/serverless/issues

Error:
Error: `python3 -u /Users/yhkee0404/python-polylith-example/projects/my_aws_lambda_project/node_modules/serverless/lib/plugins/aws/invoke-local/runtime-wrappers/invoke.py example.messages_lambda.core handler` Exited with code 1
    at ChildProcess.<anonymous> (/Users/yhkee0404/python-polylith-example/projects/my_aws_lambda_project/node_modules/child-process-ext/spawn.js:38:8)
    at ChildProcess.emit (node:events:513:28)
    at ChildProcess.emit (node:domain:489:12)
    at maybeClose (node:internal/child_process:1091:16)
    at ChildProcess._handle.onexit (node:internal/child_process:302:5)
```